### PR TITLE
CardPreviewコンポーネントにオーバーレイ表示の条件を追加

### DIFF
--- a/components/card-preview.tsx
+++ b/components/card-preview.tsx
@@ -30,6 +30,7 @@ export function CardPreview({
 }: CardPreviewProps) {
 	const resolvedGradient = resolveGradient(gradient);
 	const gradientStyles = CARD_GRADIENTS[resolvedGradient];
+	const showOverlay = resolvedGradient !== "knowledge";
 	const rootClassName = [
 		"relative flex h-[210px] w-[160px] flex-col items-center justify-center gap-[24px] overflow-hidden rounded-[36px] bg-gradient-to-b p-[36px] shadow-[0px_24px_48px_0px_rgba(0,0,0,0.25)] ring-8 ring-white",
 		gradientStyles.gradientClassName,
@@ -69,12 +70,14 @@ export function CardPreview({
 					/>
 				</div>
 			</div>
-			<div
-				className="pointer-events-none absolute inset-0 rounded-[inherit]"
-				style={{
-					boxShadow: `inset 0px 0px 64px 0px ${gradientStyles.glowColor}`,
-				}}
-			/>
+			{showOverlay ? (
+				<div
+					className="pointer-events-none absolute inset-0 rounded-[inherit]"
+					style={{
+						boxShadow: `inset 0px 0px 64px 0px ${gradientStyles.glowColor}`,
+					}}
+				/>
+			) : null}
 		</div>
 	);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overlay rendering behavior on card previews to display conditionally based on gradient settings rather than always appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->